### PR TITLE
[jd] should the anchor tag be replaced by a Link tag?

### DIFF
--- a/src/components/shows/ShowListing.js
+++ b/src/components/shows/ShowListing.js
@@ -1,10 +1,11 @@
+import {Link} from 'react-router-dom'
 import "./ShowListing.css";
 
 export default function ShowListing({ show }) {
   return (
     <article className="show">
       <h3 className="title">
-        <a href={`/shows/${show.id}`}>{show.title}</a>
+        <Link to={`/shows/${show.id}`}>{show.title}</Link>
       </h3>
       <p className="description">{show.description}</p>
       <aside className="details">


### PR DESCRIPTION
In the ShowListing.js component of the lab, won't the **anchor tag** trigger a complete re-render of the application? 

<img width="557" alt="Screen Shot 2022-09-29 at 3 17 13 PM" src="https://user-images.githubusercontent.com/104039211/193122603-f4523056-139b-47a6-b58f-68f7581c4d6b.png">

I think here we are instead meaning to navigate to the individual movie title without triggering a re-render of the complete application, which the React router **Link** tag would solve. ( Unless fellows are supposed to change it later, but I haven't noticed that yet.)

<img width="651" alt="Screen Shot 2022-09-29 at 3 21 55 PM" src="https://user-images.githubusercontent.com/104039211/193123489-870d22b2-5110-434f-9cb4-5c202fa6c4ab.png">
